### PR TITLE
change: update and fix adblock

### DIFF
--- a/src/main/java/club/sk1er/hytilities/config/HytilitiesConfig.java
+++ b/src/main/java/club/sk1er/hytilities/config/HytilitiesConfig.java
@@ -8,12 +8,12 @@ import java.io.File;
 
 public class HytilitiesConfig extends Vigilant {
 
-    /*@Property(
+    @Property(
         type = PropertyType.SWITCH, name = "Ad Blocker",
         description = "Remove spam messages, typically advertising something.",
         category = "Chat", subcategory = "Toggles"
     )
-    public static boolean hytilitiesAdblock;*/
+    public static boolean hytilitiesAdblock;
 
     /*@Property(
         type = PropertyType.SWITCH, name = "Remove Line Separators",

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/ChatHandler.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/ChatHandler.java
@@ -19,7 +19,7 @@ public class ChatHandler {
     private final List<ChatModule> moduleList = new ArrayList<>();
 
     public ChatHandler() {
-        //this.registerModule(new AdBlocker());
+        this.registerModule(new AdBlocker());
         this.registerModule(new ChatCleaner());
         this.registerModule(new ChatRestyler());
         this.registerModule(new WhiteChat());

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/adblock/AdBlocker.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/adblock/AdBlocker.java
@@ -2,24 +2,32 @@ package club.sk1er.hytilities.handlers.chat.adblock;
 
 import club.sk1er.hytilities.config.HytilitiesConfig;
 import club.sk1er.hytilities.handlers.chat.ChatModule;
-import club.sk1er.mods.core.util.MinecraftUtils;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 
 import java.util.regex.Pattern;
 
 public class AdBlocker implements ChatModule {
 
-    // match "[/]<visit|ah|party|p join|guild|g join> playername"
-    // the "/" is optional as some people simply just say "ah playername"
-    // todo: this seems to remove any mention of the word "party", needs to be fixed
-    private final Pattern commonAdvertisements = Pattern.compile("/?(?:visit|ah|party|p join|guild|g join) \\w{1,16}", Pattern.CASE_INSENSITIVE);
+    // private final Pattern commonAdvertisements = Pattern.compile("/?(?:visit|ah|party|p join|guild|g join) \\w{1,16}", Pattern.CASE_INSENSITIVE);
+    // https://regexr.com/5ct51 old regex would capture any sentence with party and "ah"
+
+    /**
+     * [/](party join or join party) or (p join) or (guild join or join guild) or (g join)
+     * Blocks twitch.tv youtube.com/youtu.be
+     * ah + visit are common words "ah yes" would flag best to keep /ah and /visit for now?
+     * /visit|ah playername is blocked and visit /playername
+     * https://regexr.com/5ct10 current tests
+     * // TODO add more phrases to regex
+     */
+    private final Pattern commonAdvertisements = Pattern.compile("(?:/?)(((party join|join party)|p join|(guild join)|(join guild)|g join) \\w{1,16})|(twitch.tv)|(youtube.com|youtu.be)|(/(visit|ah) \\w{1,16}|(visit /\\w{1,16}))",
+            Pattern.CASE_INSENSITIVE);
 
     @Override
     public void onChatEvent(ClientChatReceivedEvent event) {
-        /*if (!HytilitiesConfig.hytilitiesAdblock) {
+        if (!HytilitiesConfig.hytilitiesAdblock) {
             return;
         }
-*/
+
         if (commonAdvertisements.matcher(event.message.getUnformattedText()).find()) {
             event.setCanceled(true);
         }


### PR DESCRIPTION
Adblock doesn't remove messages with "party" or words containing "ah" [Regex Tests](https://regexr.com/5ct10)
Currently won't block "ah playername" as we would need to guarantee it's an actual player name not just someone saying "ah randomword"