### PR TITLE
new: create a utility for parsing locraw

### DIFF
--- a/src/main/java/club/sk1er/hytilities/Hytilities.java
+++ b/src/main/java/club/sk1er/hytilities/Hytilities.java
@@ -12,6 +12,7 @@ import club.sk1er.hytilities.handlers.lobby.limbo.LimboLimiter;
 import club.sk1er.hytilities.handlers.lobby.npc.NPCHider;
 import club.sk1er.hytilities.handlers.server.ServerChecker;
 import club.sk1er.hytilities.handlers.silent.SilentRemoval;
+import club.sk1er.hytilities.util.locraw.LocrawUtil;
 import club.sk1er.modcore.ModCoreInstaller;
 import club.sk1er.mods.core.universal.ChatColor;
 import club.sk1er.mods.core.util.MinecraftUtils;
@@ -38,6 +39,7 @@ public class Hytilities {
 
     private final HytilitiesConfig config = new HytilitiesConfig();
     private SilentRemoval silentRemoval;
+    private LocrawUtil locrawUtil;
 
     private boolean loadedCall;
 
@@ -61,6 +63,7 @@ public class Hytilities {
         // general stuff
         MinecraftForge.EVENT_BUS.register(new AutoStart());
         MinecraftForge.EVENT_BUS.register(new ServerChecker());
+        MinecraftForge.EVENT_BUS.register(locrawUtil = new LocrawUtil());
 
         // chat
         MinecraftForge.EVENT_BUS.register(silentRemoval = new SilentRemoval());
@@ -80,6 +83,10 @@ public class Hytilities {
 
     public HytilitiesConfig getConfig() {
         return config;
+    }
+
+    public LocrawUtil getLocrawUtil() {
+        return locrawUtil;
     }
 
     public SilentRemoval getSilentRemoval() {

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/ChatHandler.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/ChatHandler.java
@@ -1,5 +1,6 @@
 package club.sk1er.hytilities.handlers.chat;
 
+import club.sk1er.hytilities.Hytilities;
 import club.sk1er.hytilities.handlers.chat.adblock.AdBlocker;
 import club.sk1er.hytilities.handlers.chat.cleaner.ChatCleaner;
 import club.sk1er.hytilities.handlers.chat.events.AchievementEvent;
@@ -24,6 +25,7 @@ public class ChatHandler {
         this.registerModule(new ChatRestyler());
         this.registerModule(new WhiteChat());
         this.registerModule(new LevelupEvent());
+        this.registerModule(Hytilities.INSTANCE.getLocrawUtil());
         this.registerModule(new AchievementEvent());
         this.registerModule(new AutoChatSwapper());
     }

--- a/src/main/java/club/sk1er/hytilities/util/locraw/LocrawInformation.java
+++ b/src/main/java/club/sk1er/hytilities/util/locraw/LocrawInformation.java
@@ -1,0 +1,18 @@
+package club.sk1er.hytilities.util.locraw;
+
+import club.sk1er.hytilities.handlers.game.GameType;
+import com.google.gson.annotations.SerializedName;
+
+public class LocrawInformation {
+
+    @SerializedName("server")
+    public String serverId;
+    @SerializedName("mode")
+    public String gameMode;
+    @SerializedName("map")
+    public String mapName;
+
+    @SerializedName("gametype")
+    public GameType gameType;
+
+}

--- a/src/main/java/club/sk1er/hytilities/util/locraw/LocrawUtil.java
+++ b/src/main/java/club/sk1er/hytilities/util/locraw/LocrawUtil.java
@@ -1,0 +1,72 @@
+package club.sk1er.hytilities.util.locraw;
+
+import club.sk1er.hytilities.handlers.chat.ChatModule;
+import club.sk1er.mods.core.util.MinecraftUtils;
+import club.sk1er.mods.core.util.Multithreading;
+import com.google.gson.Gson;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class LocrawUtil implements ChatModule {
+
+    public LocrawInformation locrawInformation;
+
+    private final Gson gson = new Gson();
+    private boolean listening;
+    private long lastWorldLoad = System.currentTimeMillis();
+
+    @SubscribeEvent
+    public void onWorldLoad(WorldEvent.Load event) {
+        if (!MinecraftUtils.isHypixel()) return; // Make sure that we're on Hypixel.
+
+        // Forge likes to fire this event multiple times, so let's work around that.
+        if (System.currentTimeMillis() - lastWorldLoad < 3000) return;
+        lastWorldLoad = System.currentTimeMillis();
+
+        Multithreading.runAsync(() -> {
+            try {
+                int tries = 0;
+                // If the player is null and we haven't tried 10 times, keep trying.
+                while (Minecraft.getMinecraft().thePlayer == null && tries < 10) {
+                    tries++;
+                    Thread.sleep(100L);
+                }
+            } catch (Exception ignored) {}
+
+            // Can't do anything if after all that the player is null, return.
+            if (Minecraft.getMinecraft().thePlayer == null) return;
+
+            try {
+                // Hypixel sometimes does this thing where it'll report its location as limbo, instead
+                // of the full location for ~1 second, just to be safe we do this to prevent that.
+                Thread.sleep(1000);
+
+                listening = true;
+                Minecraft.getMinecraft().thePlayer.sendChatMessage("/locraw");
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    @Override
+    public void onChatEvent(ClientChatReceivedEvent event) {
+        if (listening) {
+            try {
+                // Had some false positives while testing, so this is here just to be safe.
+                String msg = event.message.getUnformattedTextForChat();
+                if (msg.startsWith("{")) {
+                    // Parse the json, and make sure that it's not null.
+                    locrawInformation = gson.fromJson(msg, LocrawInformation.class);
+                    if (locrawInformation != null) {
+                        // Stop listening for locraw and cancel the message.
+                        event.setCanceled(true);
+                        listening = false;
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
+    }
+}


### PR DESCRIPTION
Made a utility to make getting information from /locraw easier.

LocrawUtil (access via Hytilities.INSTANCE.getLocrawUtil()) provides access to the last obtained values from /locraw (performed automatically when the world is loaded).

Currently, the LocrawInformation class which is used to store data such as:

1. The Server ID, ex: mini123D or swlobby24
2. The GameMode, ex: solo_insane, or bedwars_eight_one
3. The Map, ex: Martian or Shire
4. The GameType, which is just the GameType enum.