### PR TITLE
fix: add a null check to the lobby checker

### DIFF
--- a/src/main/java/club/sk1er/hytilities/handlers/lobby/LobbyChecker.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/lobby/LobbyChecker.java
@@ -16,15 +16,11 @@ public class LobbyChecker {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void retrieveLocraw(ClientChatReceivedEvent event) {
-        if (!MinecraftUtils.isHypixel()) {
+        if (!MinecraftUtils.isHypixel() || Hytilities.INSTANCE.getLocrawUtil().getLocrawInformation() == null) {
             this.lobbyStatus = false;
             return;
         }
 
-        // todo: information can be null when invoked for the first time
-        // find a way around this, maybe schedule it for a few seconds?
-        // everything i've tried hasn't worked, so this will do for now, just wont
-        // work the first time around.
         final LocrawInformation info = Hytilities.INSTANCE.getLocrawUtil().getLocrawInformation();
         this.lobbyStatus = this.lobbyPattern.matcher(info.getServerId()).matches();
     }


### PR DESCRIPTION
This PR makes changes to [LobbyChecker](https://github.com/littlemissantivirus/Hytilities/blob/e5a52d327f40cf86335b037dc6af3bd889132aae/src/main/java/club/sk1er/hytilities/handlers/lobby/LobbyChecker.java) which simply just adds in a null check to prevent the log being spammed with errors, however the mod will report the server as *not* being a lobby for ~3 seconds on first join.