### PR TITLE
fix: sword & armour not appearing while in the duels pvp arena

### DIFF
--- a/src/main/java/club/sk1er/hytilities/util/locraw/LocrawInformation.java
+++ b/src/main/java/club/sk1er/hytilities/util/locraw/LocrawInformation.java
@@ -8,7 +8,7 @@ public class LocrawInformation {
     @SerializedName("server")
     private String serverId;
     @SerializedName("mode")
-    private String gameMode;
+    private String gameMode = "lobby";
     @SerializedName("map")
     private String mapName;
 


### PR DESCRIPTION
When playing in the duels pvp arena, armour and items would not be rendered on a player due to the gameMode in LocrawInformation being checked but returning null. This has been fixed by making it just return `lobby` when it's unknown so similar stuff doesn't happen in the future.