### PR TITLE
new: allow changing the channel to swap to when chat swapper activates

### DIFF
--- a/src/main/java/club/sk1er/hytilities/config/HytilitiesConfig.java
+++ b/src/main/java/club/sk1er/hytilities/config/HytilitiesConfig.java
@@ -210,7 +210,15 @@ public class HytilitiesConfig extends Vigilant {
         description = "Hide the \"§aYou are now in the §6ALL§a channel§r\" message when auto-switching.",
         category = "Chat", subcategory = "Parties"
     )
-    public static boolean hytilitiesHideAllChatMessage;
+    public static boolean hideAllChatMessage;
+
+    @Property(
+        type = PropertyType.SELECTOR, name = "Chat Swapper Channel",
+        description = "The channel to return to after being kicked from a party",
+        category = "Chat", subcategory = "Parties",
+        options = {"ALL", "GUILD", "OFFICER"}
+    )
+    public static int chatSwapperReturnChannel;
 
     public HytilitiesConfig() {
         super(new File("./config/hytilities.toml"));

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/swapper/AutoChatSwapper.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/swapper/AutoChatSwapper.java
@@ -29,9 +29,6 @@ public class AutoChatSwapper implements ChatModule {
             MinecraftForge.EVENT_BUS.register(new ChatChannelMessagePreventer());
 
             switch (HytilitiesConfig.chatSwapperReturnChannel) {
-                case 0:
-                    Hytilities.INSTANCE.getCommandQueue().queue("/chat a");
-                    break;
                 case 1:
                     Hytilities.INSTANCE.getCommandQueue().queue("/chat g");
                     break;
@@ -40,7 +37,6 @@ public class AutoChatSwapper implements ChatModule {
                     break;
                 default:
                     Hytilities.INSTANCE.getCommandQueue().queue("/chat a");
-                    HytilitiesConfig.chatSwapperReturnChannel = 0;
                     break;
             }
 

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/swapper/AutoChatSwapper.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/swapper/AutoChatSwapper.java
@@ -31,7 +31,6 @@ public class AutoChatSwapper implements ChatModule {
             switch (HytilitiesConfig.chatSwapperReturnChannel) {
                 case 0:
                     Hytilities.INSTANCE.getCommandQueue().queue("/chat a");
-                    HytilitiesConfig.chatSwapperReturnChannel = 0;
                     break;
                 case 1:
                     Hytilities.INSTANCE.getCommandQueue().queue("/chat g");
@@ -41,6 +40,7 @@ public class AutoChatSwapper implements ChatModule {
                     break;
                 default:
                     Hytilities.INSTANCE.getCommandQueue().queue("/chat a");
+                    HytilitiesConfig.chatSwapperReturnChannel = 0;
                     break;
             }
 

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/swapper/AutoChatSwapper.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/swapper/AutoChatSwapper.java
@@ -27,7 +27,23 @@ public class AutoChatSwapper implements ChatModule {
         final Matcher statusMatcher = this.partyStatusRegex.matcher(event.message.getUnformattedText());
         if (statusMatcher.matches()) {
             MinecraftForge.EVENT_BUS.register(new ChatChannelMessagePreventer());
-            Hytilities.INSTANCE.getCommandQueue().queue("/chat a");
+
+            switch (HytilitiesConfig.chatSwapperReturnChannel) {
+                case 0:
+                    Hytilities.INSTANCE.getCommandQueue().queue("/chat a");
+                    HytilitiesConfig.chatSwapperReturnChannel = 0;
+                    break;
+                case 1:
+                    Hytilities.INSTANCE.getCommandQueue().queue("/chat g");
+                    break;
+                case 2:
+                    Hytilities.INSTANCE.getCommandQueue().queue("/chat o");
+                    break;
+                default:
+                    Hytilities.INSTANCE.getCommandQueue().queue("/chat a");
+                    break;
+            }
+
         }
     }
 
@@ -40,6 +56,7 @@ public class AutoChatSwapper implements ChatModule {
 
         private boolean hasDetected;
         private final ScheduledFuture<?> unregisterTimer;
+        private final Pattern channelSwapRegex = Pattern.compile("^(?:You are now in the (?<channel>ALL|GUILD|OFFICER) channel)");
 
         ChatChannelMessagePreventer() { // if the message somehow doesn't send, we unregister after 20 seconds
             unregisterTimer = Multithreading.schedule(() -> { // to prevent blocking the next time it's used
@@ -53,8 +70,8 @@ public class AutoChatSwapper implements ChatModule {
         @SubscribeEvent
         public void checkForAlreadyInThisChannelThing(ClientChatReceivedEvent event) {
             if ("You're already in this channel!".equals(event.message.getUnformattedText())
-                    || (HytilitiesConfig.hytilitiesHideAllChatMessage &&
-                    "You are now in the ALL channel".equals(event.message.getUnformattedText()))
+                    || (HytilitiesConfig.hideAllChatMessage &&
+                    channelSwapRegex.matcher(event.message.getUnformattedText()).matches())
             ) {
                 unregisterTimer.cancel(false);
                 hasDetected = true;

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/swapper/AutoChatSwapper.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/swapper/AutoChatSwapper.java
@@ -36,6 +36,7 @@ public class AutoChatSwapper implements ChatModule {
                     Hytilities.INSTANCE.getCommandQueue().queue("/chat o");
                     break;
                 default:
+                case 0:
                     Hytilities.INSTANCE.getCommandQueue().queue("/chat a");
                     break;
             }

--- a/src/main/java/club/sk1er/hytilities/util/locraw/LocrawInformation.java
+++ b/src/main/java/club/sk1er/hytilities/util/locraw/LocrawInformation.java
@@ -16,26 +16,44 @@ public class LocrawInformation {
     private String rawGameType;
     private GameType gameType;
 
+    /**
+     * @return The serverID of the server you are currently on, ex: mini121
+     */
     public String getServerId() {
         return serverId;
     }
 
+    /**
+     * @return The GameType of the server as a String.
+     */
     public String getRawGameType() {
         return rawGameType;
     }
 
+    /**
+     * @return The GameMode of the server, ex: solo_insane
+     */
     public String getGameMode() {
         return gameMode;
     }
 
+    /**
+     * @param gameType The GameType to set it to.
+     */
     public void setGameType(GameType gameType) {
         this.gameType = gameType;
     }
 
+    /**
+     * @return The GameType of the server as an Enum.
+     */
     public GameType getGameType() {
         return gameType;
     }
 
+    /**
+     * @return The map of the server, ex: Shire.
+     */
     public String getMapName() {
         return mapName;
     }

--- a/src/main/java/club/sk1er/hytilities/util/locraw/LocrawUtil.java
+++ b/src/main/java/club/sk1er/hytilities/util/locraw/LocrawUtil.java
@@ -16,7 +16,6 @@ public class LocrawUtil implements ChatModule {
     private final Gson gson = new Gson();
     private LocrawInformation locrawInformation;
     private boolean listening;
-    private long lastWorldLoad = System.currentTimeMillis();
     private int tick;
 
     @SubscribeEvent


### PR DESCRIPTION
This PR adds in a feature where users can select what channel to return to when being kicked from a party (ALL, GUILD, OFFICER) [Preview](https://i.imgur.com/BFB2AQE.png)