### PR TITLE
fix: leveling up not giving proper chat message

### DIFF
--- a/src/main/java/club/sk1er/hytilities/handlers/chat/events/LevelupEvent.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/events/LevelupEvent.java
@@ -26,7 +26,7 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/events/LevelupEvent.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/events/LevelupEvent.java
@@ -29,17 +29,13 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class LevelupEvent implements ChatReceiveModule {
-
-    private final Pattern levelUpPattern = Pattern.compile("You are now Hypixel Level (?<level>\\d+)!");
-
     @Override
     public void onChatEvent(ClientChatReceivedEvent event) {
         String unformattedText = EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText());
 
-        Matcher matcher = levelUpPattern.matcher(unformattedText.trim());
+        Matcher matcher = getLanguage().hypixelLevelUpRegex.matcher(unformattedText.trim());
         if (matcher.find()) {
             String level = matcher.group("level");
 

--- a/src/main/java/club/sk1er/hytilities/handlers/language/LanguageData.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/language/LanguageData.java
@@ -78,6 +78,8 @@ public class LanguageData {
     public String cannotShoutBeforeGame = "You can't use /shout before the game has started.";
     public String cannotShoutAfterGame = "You can't use /shout after the game has finished.";
 
+    private String hypixelLevelUp = "You are now Hypixel Level (?<level>\\d+)!";
+
     /**
      * Cached values which use the messages read from the config file.
      * Particularly Regexes.
@@ -112,6 +114,8 @@ public class LanguageData {
     public Pattern privateMessageWhiteChatRegex;
     public Pattern silentRemovalLeaveMessageRegex;
 
+    public Pattern hypixelLevelUpRegex;
+
     /**
      * Compiles all the required patterns and caches them for later use.
      */
@@ -145,6 +149,8 @@ public class LanguageData {
         whiteChatNonMessageRegex = Pattern.compile(whiteChatNonMessage);
         privateMessageWhiteChatRegex = Pattern.compile(privateMessageWhiteChat);
         silentRemovalLeaveMessageRegex = Pattern.compile(silentRemovalLeaveMessage);
+
+        hypixelLevelUpRegex = Pattern.compile(hypixelLevelUp);
     }
 
 }

--- a/src/main/resources/languages/en.json
+++ b/src/main/resources/languages/en.json
@@ -31,5 +31,6 @@
   "noSpectatorCommands": "You are not allowed to use commands as a spectator!",
   "cannotShoutBeforeSkywars": "You can't shout until the game has started!",
   "cannotShoutBeforeBedwars": "You can't use /shout before the game has started.",
-  "cannotShoutInSoloBedwars": "You can't use /shout in this mode."
+  "cannotShoutInSoloBedwars": "You can't use /shout in this mode.",
+  "hypixelLevelUp": "You are now Hypixel Level (?<level>\\\\d+)!"
 }


### PR DESCRIPTION
That was a 1 letter fix, but still very meaningful one.

Issue was that `org.apache.commons.lang.StringUtils` was not found from the modcore jar for some reason.
This fix makes Hytilities use `org.apache.commons.lang3.StringUtils` in `LevelupEvent`. This should not cause a NoClassDefFoundError, since it is in Minecraft's runtime already.

Also moves the levelup regex to `LanguageData`, because it should be there and I don't want to make this a 1 char add PR.