### PR TITLE
fix: mystery box star not getting vip/mvp boxes

### DIFF
--- a/src/main/java/club/sk1er/hytilities/config/HytilitiesConfig.java
+++ b/src/main/java/club/sk1er/hytilities/config/HytilitiesConfig.java
@@ -304,7 +304,7 @@ public class HytilitiesConfig extends Vigilant {
 
     @Property(
         type = PropertyType.SWITCH, name = "Mystery Box Star",
-        description = "Shows what star a mystery box is in the Mystery Box Vault, Orange stars are special boxes.\n§eExample: §e5✰\n§6✰",
+        description = "Shows what star a mystery box is in the Mystery Box Vault, Orange stars are special boxes.",
         category = "Lobby", subcategory = "GUI"
     )
     public static boolean mysteryBoxStar;

--- a/src/main/java/club/sk1er/hytilities/handlers/lobby/mysterybox/MysteryBoxStar.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/lobby/mysterybox/MysteryBoxStar.java
@@ -24,12 +24,10 @@ import club.sk1er.mods.core.util.MinecraftUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiChest;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -92,8 +90,7 @@ public class MysteryBoxStar {
             int stars = matcher.group("stars").length();
             // yellow stars for regular boxes
             Minecraft.getMinecraft().fontRendererObj.drawStringWithShadow(stars + "\u2730", x, y, -14080);
-        }
-        else{
+        } else {
             // for boxes with vip/mvp+ access
             String line1 = tooltip.get(tooltip.size() - 5);
             Matcher matcher1 = mysteryBoxStarPattern.matcher(line1);

--- a/src/main/java/club/sk1er/hytilities/handlers/lobby/mysterybox/MysteryBoxStar.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/lobby/mysterybox/MysteryBoxStar.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 
 public class MysteryBoxStar {
 
-    private final Pattern mysteryBoxStarPattern = Pattern.compile("^\\u00a75\\u00a7o\\u00a77\\u00a77Quality: \\u00a7e(?<stars>\\u2730{1,5}).*");
+    private final Pattern mysteryBoxStarPattern = Pattern.compile("\\u00a75\\u00a7o\\u00a77\\u00a77Quality: \\u00a7e(?<stars>\\u2730+).*");
 
     @SubscribeEvent
     public void onDrawScreenPre(GuiScreenEvent.DrawScreenEvent.Pre event) {
@@ -76,11 +76,6 @@ public class MysteryBoxStar {
     }
 
     public void drawStars(ItemStack item, int x, int y) {
-        // avoid rendering star when no mystery boxes are present
-        if (item.getItem() == Item.getItemFromBlock(Blocks.stained_glass_pane)) {
-            return;
-        }
-
         // avoid rendering star on bags of experience
         if (item.getItem() == Items.dye) {
             return;
@@ -91,14 +86,22 @@ public class MysteryBoxStar {
         if (tooltip.size() < 4) {
             return;
         }
-
         String line = tooltip.get(tooltip.size() - 4);
         Matcher matcher = mysteryBoxStarPattern.matcher(line);
         if (matcher.matches()) {
             int stars = matcher.group("stars").length();
             // yellow stars for regular boxes
             Minecraft.getMinecraft().fontRendererObj.drawStringWithShadow(stars + "\u2730", x, y, -14080);
-        } else {
+        }
+        else{
+            // for boxes with vip/mvp+ access
+            String line1 = tooltip.get(tooltip.size() - 5);
+            Matcher matcher1 = mysteryBoxStarPattern.matcher(line1);
+            if (matcher1.matches()) {
+                int stars = matcher1.group("stars").length();
+                Minecraft.getMinecraft().fontRendererObj.drawStringWithShadow(stars + "\u2730", x, y, -14080);
+                return;
+            }
             // not a regular box, so assume it is a special box. e.g. holiday boxes
             // orange stars for special boxes
             Minecraft.getMinecraft().fontRendererObj.drawStringWithShadow("\u2730", x, y, -34304);

--- a/src/main/java/club/sk1er/hytilities/handlers/lobby/mysterybox/MysteryBoxStar.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/lobby/mysterybox/MysteryBoxStar.java
@@ -31,6 +31,8 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraft.item.Item;
+import net.minecraft.init.Blocks;
 
 import java.util.List;
 import java.util.regex.Matcher;
@@ -74,6 +76,11 @@ public class MysteryBoxStar {
     }
 
     public void drawStars(ItemStack item, int x, int y) {
+        // avoid rendering star when no mystery boxes are present
+        if (item.getItem() == Item.getItemFromBlock(Blocks.stained_glass_pane)) {
+            return;
+        }
+
         // avoid rendering star on bags of experience
         if (item.getItem() == Items.dye) {
             return;


### PR DESCRIPTION
I also removed "avoid rendering star when no mystery boxes are present" as it already checks for the right slot and removed the example from the description.