### PR TITLE
new: clean skyblock tab

### DIFF
--- a/src/main/java/club/sk1er/hytilities/config/HytilitiesConfig.java
+++ b/src/main/java/club/sk1er/hytilities/config/HytilitiesConfig.java
@@ -189,6 +189,13 @@ public class HytilitiesConfig extends Vigilant {
     public static boolean hidePlayerRanksInTab;
 
     @Property(
+        type = PropertyType.SWITCH, name = "Cleaner Tab in Skyblock",
+        description = "Doesn't render player heads or ping for tab entries that aren't players in Skyblock.",
+        category = "General", subcategory = "General"
+    )
+    public static boolean cleanerSkyblockTabInfo;
+
+    @Property(
         type = PropertyType.SWITCH, name = "Hide Ping In Tab",
         description = "Prevent ping from showing up in tab while playing games, since the value is misleading. Ping will remain visible in lobbies.",
         category = "General", subcategory = "General"

--- a/src/main/java/club/sk1er/hytilities/handlers/lobby/tab/TabChanger.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/lobby/tab/TabChanger.java
@@ -20,9 +20,14 @@ package club.sk1er.hytilities.handlers.lobby.tab;
 
 import club.sk1er.hytilities.Hytilities;
 import club.sk1er.hytilities.config.HytilitiesConfig;
+import club.sk1er.hytilities.handlers.game.GameType;
 import club.sk1er.hytilities.tweaker.asm.GuiPlayerTabOverlayTransformer;
+import club.sk1er.hytilities.util.locraw.LocrawInformation;
 import club.sk1er.mods.core.util.MinecraftUtils;
+import net.minecraft.client.network.NetworkPlayerInfo;
 import org.objectweb.asm.tree.ClassNode;
+
+import java.util.regex.Pattern;
 
 /**
  * Used in {@link GuiPlayerTabOverlayTransformer#transform(ClassNode, String)}
@@ -52,7 +57,23 @@ public class TabChanger {
         return name;
     }
 
-    public static boolean hidePing() {
-        return MinecraftUtils.isHypixel() && HytilitiesConfig.hidePingInTab && !Hytilities.INSTANCE.getLobbyChecker().playerIsInLobby();
+    public static boolean shouldRenderPlayerHead(NetworkPlayerInfo networkPlayerInfo) {
+        return !MinecraftUtils.isHypixel() || !isSkyblockTabInformationEntry(networkPlayerInfo);
+    }
+
+    public static boolean hidePing(NetworkPlayerInfo networkPlayerInfo) {
+        return MinecraftUtils.isHypixel() && ((HytilitiesConfig.hidePingInTab && !Hytilities.INSTANCE.getLobbyChecker().playerIsInLobby()) || isSkyblockTabInformationEntry(networkPlayerInfo));
+    }
+
+    private static final Pattern validMinecraftUsername = Pattern.compile("[A-Za-z0-9_]{1,16}");
+    private static final Pattern skyblockTabInformationEntryGameProfileNameRegex = Pattern.compile("![A-D]-[a-v]");
+    private static boolean isSkyblockTabInformationEntry(NetworkPlayerInfo networkPlayerInfo) {
+        if (!HytilitiesConfig.cleanerSkyblockTabInfo) return false;
+        LocrawInformation locraw = Hytilities.INSTANCE.getLocrawUtil().getLocrawInformation();
+        return
+            locraw != null &&
+            locraw.getGameType().equals(GameType.SKYBLOCK) &&
+            skyblockTabInformationEntryGameProfileNameRegex.matcher(networkPlayerInfo.getGameProfile().getName()).matches() &&
+            !validMinecraftUsername.matcher(networkPlayerInfo.getDisplayName().getUnformattedText()).matches();
     }
 }

--- a/src/main/java/club/sk1er/hytilities/tweaker/asm/GuiPlayerTabOverlayTransformer.java
+++ b/src/main/java/club/sk1er/hytilities/tweaker/asm/GuiPlayerTabOverlayTransformer.java
@@ -20,14 +20,7 @@ package club.sk1er.hytilities.tweaker.asm;
 
 import club.sk1er.hytilities.tweaker.transformer.HytilitiesTransformer;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.AbstractInsnNode;
-import org.objectweb.asm.tree.ClassNode;
-import org.objectweb.asm.tree.InsnList;
-import org.objectweb.asm.tree.InsnNode;
-import org.objectweb.asm.tree.JumpInsnNode;
-import org.objectweb.asm.tree.LabelNode;
-import org.objectweb.asm.tree.MethodInsnNode;
-import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.*;
 
 import java.util.ListIterator;
 
@@ -50,7 +43,7 @@ public class GuiPlayerTabOverlayTransformer implements HytilitiesTransformer {
                     while (iterator.hasNext()) {
                         AbstractInsnNode next = iterator.next();
 
-                        if (next instanceof MethodInsnNode && next.getOpcode() == Opcodes.INVOKEVIRTUAL) {
+                        if (next.getOpcode() == Opcodes.INVOKEVIRTUAL) {
                             String methodInsnName = mapMethodNameFromNode(next);
 
                             // sort the player map and filter any entity with a uuid version of 2
@@ -60,8 +53,9 @@ public class GuiPlayerTabOverlayTransformer implements HytilitiesTransformer {
                                     "hideTabNpcs",
                                     "(Ljava/util/Collection;)Ljava/util/Collection;",
                                     false));
-                                break;
                             }
+                        } else if (next.getOpcode() == Opcodes.ILOAD && ((VarInsnNode) next).var == 11 && next.getNext().getOpcode() == Opcodes.IFEQ && !(next.getPrevious() instanceof VarInsnNode && ((VarInsnNode)next.getPrevious()).var == 10)) {
+                            method.instructions.insert(next.getNext(), shouldRenderPlayerHead(((JumpInsnNode) next.getNext()).label));
                         }
                     }
                     break;
@@ -70,7 +64,7 @@ public class GuiPlayerTabOverlayTransformer implements HytilitiesTransformer {
                     while (iterator.hasNext()) {
                         AbstractInsnNode next = iterator.next();
 
-                        if (next instanceof MethodInsnNode && next.getOpcode() == Opcodes.INVOKESTATIC) {
+                        if (next.getOpcode() == Opcodes.INVOKESTATIC) {
                             String methodInsnName = mapMethodNameFromNode(next);
 
                             // trim the player name to remove player ranks and guild tags
@@ -93,10 +87,19 @@ public class GuiPlayerTabOverlayTransformer implements HytilitiesTransformer {
         }
     }
 
+    private InsnList shouldRenderPlayerHead(LabelNode label) {
+        InsnList list = new InsnList();
+        list.add(new VarInsnNode(Opcodes.ALOAD, 24)); // networkplayerinfo1
+        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "club/sk1er/hytilities/handlers/lobby/tab/TabChanger", "shouldRenderPlayerHead", "(Lnet/minecraft/client/network/NetworkPlayerInfo;)Z", false));
+        list.add(new JumpInsnNode(Opcodes.IFEQ, label));
+        return list;
+    }
+
     private InsnList hidePing() {
         InsnList list = new InsnList();
         LabelNode label = new LabelNode();
-        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "club/sk1er/hytilities/handlers/lobby/tab/TabChanger", "hidePing", "()Z", false));
+        list.add(new VarInsnNode(Opcodes.ALOAD, 4));
+        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "club/sk1er/hytilities/handlers/lobby/tab/TabChanger", "hidePing", "(Lnet/minecraft/client/network/NetworkPlayerInfo;)Z", false));
         list.add(new JumpInsnNode(Opcodes.IFEQ, label));
         list.add(new InsnNode(Opcodes.RETURN));
         list.add(label);


### PR DESCRIPTION
No more gray skins and 0 ping for them in tab for the info in tab in skyblock.

Off:
![2020-10-11_19 13 18](https://user-images.githubusercontent.com/20520700/95684303-6093e700-0bf9-11eb-84eb-c67f14150ba0.png)

On:
![2020-10-11_19 13 01](https://user-images.githubusercontent.com/20520700/95684321-7b665b80-0bf9-11eb-8549-c3e4ac1f32f9.png)
