### PR TITLE
new: license copyright notices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ classes
 *.ipr
 *.iws
 *.iml
-.idea
+.idea/*
+!.idea/copyright
 
 # gradle
 build

--- a/.idea/copyright/Hytilities.xml
+++ b/.idea/copyright/Hytilities.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Hytilities - Hypixel focused Quality of Life mod.&#10;Copyright (C) &amp;#36;today.year  Sk1er LLC&#10;&#10;This program is free software: you can redistribute it and/or modify&#10;it under the terms of the GNU General Public License as published by&#10;the Free Software Foundation, either version 3 of the License, or&#10;(at your option) any later version.&#10;&#10;This program is distributed in the hope that it will be useful,&#10;but WITHOUT ANY WARRANTY; without even the implied warranty of&#10;MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the&#10;GNU General Public License for more details.&#10;&#10;You should have received a copy of the GNU General Public License&#10;along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;." />
+    <option name="myName" value="Hytilities" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="Hytilities" />
+</component>

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/ChatReceiveModule.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/ChatReceiveModule.java
@@ -1,3 +1,21 @@
+/*
+ * Hytilities - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2020  Sk1er LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package club.sk1er.hytilities.handlers.chat;
 
 import net.minecraftforge.client.event.ClientChatReceivedEvent;

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/ChatSendModule.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/ChatSendModule.java
@@ -1,3 +1,21 @@
+/*
+ * Hytilities - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2020  Sk1er LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package club.sk1er.hytilities.handlers.chat;
 
 import net.minecraftforge.client.event.ClientChatReceivedEvent;

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/modules/blockers/ShoutBlocker.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/modules/blockers/ShoutBlocker.java
@@ -1,3 +1,21 @@
+/*
+ * Hytilities - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2020  Sk1er LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package club.sk1er.hytilities.handlers.chat.modules.blockers;
 
 import club.sk1er.hytilities.Hytilities;

--- a/src/main/java/club/sk1er/hytilities/tweaker/asm/EntityPlayerSPTransformer.java
+++ b/src/main/java/club/sk1er/hytilities/tweaker/asm/EntityPlayerSPTransformer.java
@@ -1,3 +1,21 @@
+/*
+ * Hytilities - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2020  Sk1er LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package club.sk1er.hytilities.tweaker.asm;
 
 import club.sk1er.hytilities.tweaker.transformer.HytilitiesTransformer;

--- a/src/main/java/club/sk1er/modcore/ModCoreInstaller.java
+++ b/src/main/java/club/sk1er/modcore/ModCoreInstaller.java
@@ -1,3 +1,21 @@
+/*
+ * Hytilities - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2020  Sk1er LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package club.sk1er.modcore;
 
 import com.google.gson.JsonArray;


### PR DESCRIPTION
It seems like there are no files to guide IntelliJ IDEA on what to put for license copyright notices so that some files won't have notices of the license.
This PR adds files for copyright notices to add the copyright notices on file creation or on `Update Copyright` and fixes missing copyright notices.

This change has no impact on how Hytilities works.