### PR TITLE
potentially fix chat style being removed by shortened channel names

### DIFF
--- a/src/main/java/club/sk1er/hytilities/handlers/chat/ChatModule.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/ChatModule.java
@@ -28,6 +28,9 @@ import net.minecraft.util.IChatComponent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * This interface handles shared methods between {@link ChatReceiveModule} and {@link ChatSendModule}.
  * It has things like priority and enabled checks, as well as default utility methods for classes
@@ -82,6 +85,32 @@ interface ChatModule {
     @NotNull
     default IChatComponent colorMessage(@NotNull String message) {
         return new ChatComponentText(ChatColor.translateAlternateColorCodes('&', message));
+    }
+
+    /**
+     * Replaces a part of the original chat message.
+     * Maintains the ChatStyle. e.g. click and hover events
+     *
+     * @param original    the original chat message from ClientChatReceivedEvent
+     * @param regex       the regular expression that matches the text to be replaced
+     * @param replacement the new text that will replace the regular expression
+     * @return            the modified chat component
+     */
+    @NotNull
+    default IChatComponent replace(IChatComponent original, String regex, String replacement) {
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher("");
+        IChatComponent editedMessage = new ChatComponentText("");
+        for (IChatComponent sibling : original.getSiblings()) {
+            String message = sibling.getFormattedText();
+            matcher.reset(message);
+            if (matcher.find()) {
+                editedMessage.appendSibling(new ChatComponentText(message.replaceAll(pattern.pattern(), replacement)));
+            } else {
+                editedMessage.appendSibling(sibling);
+            }
+        }
+        return editedMessage;
     }
 
     /**

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/modules/modifiers/DefaultChatRestyler.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/modules/modifiers/DefaultChatRestyler.java
@@ -78,14 +78,14 @@ public class DefaultChatRestyler implements ChatReceiveModule {
             Matcher guildMatcher = language.chatRestylerGuildPatternRegex.matcher(message);
             Matcher friendMatcher = language.chatRestylerFriendPatternRegex.matcher(message);
             if (partyMatcher.find()) {
-                event.message = colorMessage(message.replaceAll(language.chatRestylerPartyPatternRegex.pattern(),
-                    partyMatcher.group(1) + "P " + partyMatcher.group(3)));
+                event.message = replace(event.message, language.chatRestylerPartyPatternRegex.pattern(),
+                    partyMatcher.group(1) + "P " + partyMatcher.group(3));
             } else if (guildMatcher.find()) {
-                event.message = colorMessage(message.replaceAll(language.chatRestylerGuildPatternRegex.pattern(),
-                    guildMatcher.group(1) + "G >"));
+                event.message = replace(event.message, language.chatRestylerGuildPatternRegex.pattern(),
+                    guildMatcher.group(1) + "G >");
             } else if (friendMatcher.find()) {
-                event.message = colorMessage(message.replaceAll(language.chatRestylerFriendPatternRegex.pattern(),
-                    friendMatcher.group(1) + "F >"));
+                event.message = replace(event.message, language.chatRestylerFriendPatternRegex.pattern(),
+                    friendMatcher.group(1) + "F >");
             }
         }
 
@@ -93,10 +93,10 @@ public class DefaultChatRestyler implements ChatReceiveModule {
         // changed in the future and they need to be padded.
         if (HytilitiesConfig.padPlayerCount) {
             Matcher mf = language.chatRestylerFormattedPaddingPatternRegex.matcher(message);
-//            Matcher mu = unformattedPaddingPattern.matcher(unformattedMessage);
+            // Matcher mu = unformattedPaddingPattern.matcher(unformattedMessage);
             if (mf.find(0)) { // this only matches a small part so we need find()
                 mf.replaceAll("(§r§b" + pad(mf.group(1)) + "§r§e/§r§b" + mf.group(2) + "§r§e)");
-//                uf.replaceAll("(" + pad(mu.group(1)) + "/" + mu.group(2) + ")");
+                // uf.replaceAll("(" + pad(mu.group(1)) + "/" + mu.group(2) + ")");
 
                 joinMatcher = language.chatRestylerGameJoinStyleRegex.matcher(message); // recalculate since we padded
                 event.message = new ChatComponentText(message);


### PR DESCRIPTION
I could not get a clickable link to show up in chat, so I was not able to test the changes.
Please check whether the chat events work in party, friend, and guild chat when short channel names is enabled.