### PR TITLE
Add mod list version + Forge dependency

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,18 +1,21 @@
-[
-  {
-    "modid": "hytilities",
-    "name": "Hytilities",
-    "description": "Hypixel-focused Quality of Life mod.",
-    "version": "${version}",
-    "mcversion": "${mcversion}",
-    "url": "https://github.com/Sk1erLLC/hytilities",
-    "updateUrl": "https://sk1er.club/mods/hytilities",
-    "authorList": [
-      "Sk1erLLC"
-    ],
-    "credits": "",
-    "logoFile": "",
-    "screenshots": [],
-    "dependencies": []
-  }
-]
+{
+  "modListVersion": 2,
+  "modList": [
+    {
+      "modid": "hytilities",
+      "name": "Hytilities",
+      "description": "Hypixel-focused Quality of Life mod.",
+      "version": "${version}",
+      "mcversion": "${mcversion}",
+      "url": "https://github.com/Sk1erLLC/hytilities",
+      "updateUrl": "https://sk1er.club/mods/hytilities",
+      "authorList": [
+        "Sk1erLLC"
+      ],
+      "credits": "",
+      "logoFile": "",
+      "screenshots": [],
+      "dependencies": ["mod_MinecraftForge"]
+    }
+  ]
+}


### PR DESCRIPTION
1) **Add mod list version:** It is better to set the mod list version so that newer versions of forge don't conflict.
2) **Forge dependency:** Depending on the Forge mod prevents players from using fake versions of Forge.

**Side-note: These changes do not affect the gameplay or anything.**