### PR TITLE
Fix Java compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ version = modVersion
 group = modGroup
 archivesBaseName = modBaseName
 
-sourceCompatibility = targetCompatibility = 1.8
+sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = JavaVersion.VERSION_1_8
 compileJava.options.encoding = 'UTF-8'
 
 minecraft {


### PR DESCRIPTION
**Use the declared final constant of JavaVersion.VERSION_1_8 instead of '1.8'**
I have tested it. Completely safe. Changes nothing but the backend stuff.
I have even used it in my project.
Trust me pls!