### PR TITLE
Use updated Forge repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
         maven {
             name = "forge"
-            url = "https://files.minecraftforge.net/maven"
+            url = "https://maven.minecraftforge.net"
         }
         maven {
             name = "jitpack"


### PR DESCRIPTION
**Use 'maven.minecraftforge.net' instead of 'files.minecraftforge.net/maven'**
I have tested it. Completely safe. Changes nothing but the backend stuff.
I have even used it in my project.
Trust me pls.