### PR TITLE
Add copyright to settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,19 @@
+/*
+ * Hytilities - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2020  Sk1er LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 rootProject.name = 'Hytilities'


### PR DESCRIPTION
**I think some devs forgot to add copyright to the settings.gradle file as done in Hyperium [here](https://github.com/HyperiumClient/Hyperium/blob/master/settings.gradle).**
I have tested it. Completely safe. Does not change anything but the appearance of the file.
Even I have used it in my project.
Trust me pls.