### PR TITLE
Use binary files instead of all

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue Jul 21 12:13:41 EDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**Use 'bin' instead of 'all'**
This just decreases the download size of the Gradle wrapper.
I have tested it. Completely safe. DOES NOT change anything in production.
Even I have used it in my project.
Trust me pls!